### PR TITLE
Add column to review_requests

### DIFF
--- a/db/migrate/20200127154641_create_review_requests.rb
+++ b/db/migrate/20200127154641_create_review_requests.rb
@@ -1,11 +1,34 @@
 class CreateReviewRequests < ActiveRecord::Migration[6.0]
   def change
     create_table :review_requests do |t|
-      t.string :user_id, default: 'guest'
+      t.string :user_id
       t.string :title, null: false
-      t.string :text, null: false
+      t.string  :text, null: false
       t.boolean :is_open, default: true
       t.integer :review_count, default: 0
+      t.string :tag_1
+      t.boolean :tag_1_is_frozen, default: false
+      t.string :tag_2
+      t.boolean :tag_2_is_frozen, default: false
+      t.string :tag_3
+      t.boolean :tag_3_is_frozen, default: false
+      t.string :tag_4
+      t.boolean :tag_4_is_frozen, default: false
+      t.string :tag_5
+      t.boolean :tag_5_is_frozen, default: false
+      t.string :tag_6
+      t.boolean :tag_6_is_frozen, default: false
+      t.string :tag_7
+      t.boolean :tag_7_is_frozen, default: false
+      t.string :tag_8
+      t.boolean :tag_8_is_frozen, default: false
+      t.string :tag_9
+      t.boolean :tag_9_is_frozen, default: false
+      t.string :tag_10
+      t.boolean :tag_10_is_frozen, default: false
+      t.string :request_status, default: 'free'
+      t.string :postscript
+      t.boolean :is_frozen_by_admin, default: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,11 +13,34 @@
 ActiveRecord::Schema.define(version: 2020_01_28_065144) do
 
   create_table "review_requests", force: :cascade do |t|
-    t.string "user_id", default: "guest"
+    t.string "user_id"
     t.string "title", null: false
     t.string "text", null: false
     t.boolean "is_open", default: true
     t.integer "review_count", default: 0
+    t.string "tag_1"
+    t.boolean "tag_1_is_frozen", default: false
+    t.string "tag_2"
+    t.boolean "tag_2_is_frozen", default: false
+    t.string "tag_3"
+    t.boolean "tag_3_is_frozen", default: false
+    t.string "tag_4"
+    t.boolean "tag_4_is_frozen", default: false
+    t.string "tag_5"
+    t.boolean "tag_5_is_frozen", default: false
+    t.string "tag_6"
+    t.boolean "tag_6_is_frozen", default: false
+    t.string "tag_7"
+    t.boolean "tag_7_is_frozen", default: false
+    t.string "tag_8"
+    t.boolean "tag_8_is_frozen", default: false
+    t.string "tag_9"
+    t.boolean "tag_9_is_frozen", default: false
+    t.string "tag_10"
+    t.boolean "tag_10_is_frozen", default: false
+    t.string "request_status", default: "free"
+    t.string "postscript"
+    t.boolean "is_frozen_by_admin", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["text"], name: "index_review_requests_on_text", unique: true


### PR DESCRIPTION
# 概要  
レビューリクエストにカラムを追加しました。  
`rails db:migrate:reset`からの`rails db:migrate`で有効になると思います。  
なぜadd_columnしなかったかというと、まだDBテーブルが試作段階だからです。  

## 追加したカラム  
* tag_1～10
* tag_n_is_frozen（上記の各タグにおけるオーナーからのfreeze状態）
* request_statusカラム（リクエストの状態:freeze, :free, :limitedの保持）
* postscriptカラム（そのままP.Sの意味です）
* is_frozen_by_admin（管理者が強制的に閉じるときのためのカラム、将来的に必要かと思って）

# 心配ごと

* テーブルひとつにカラムを20個以上追加しました。こんなに多くて大丈夫なのかなと不安気味です。テーブルは分けるべきだったのでしょうか？
* タグから検索してレビューリクエストを表示するための方法が、”1～10の各タグに検索したいタグが含まれているか”を10回繰り返すしか思い浮かびません。計算量的に大丈夫なんでしょうか？もっとスマートな方法はあるのでしょうか。
* スネークケースの場合の数字表現はtag_1とかで合ってるんでしょうか？検索しても出てこなかったので不安です。