### PR TITLE
Add tags table

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/db/migrate/20200204094051_create_tags.rb
+++ b/db/migrate/20200204094051_create_tags.rb
@@ -3,7 +3,7 @@ class CreateTags < ActiveRecord::Migration[6.0]
     create_table :tags do |t|
       t.string :tag_name
       t.integer :request_id
-      t.boolean :is_frozen, default: false
+      t.boolean :is_pinned, default: false
 
       t.timestamps
     end

--- a/db/migrate/20200204094051_create_tags.rb
+++ b/db/migrate/20200204094051_create_tags.rb
@@ -1,0 +1,11 @@
+class CreateTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tags do |t|
+      t.string :tag_name
+      t.integer :request_id
+      t.boolean :is_frozen, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200204100524_change_column_to_review_requests.rb
+++ b/db/migrate/20200204100524_change_column_to_review_requests.rb
@@ -2,7 +2,7 @@ class ChangeColumnToReviewRequests < ActiveRecord::Migration[6.0]
   def change
     change_column :review_requests, :user_id, :integer
     add_column :review_requests, :request_status, :string
-    add_column :review_requests, :postscript, :string
+    add_column :review_requests, :additional_remark, :string
     add_column :review_requests, :is_frozen, :boolean, default: false
   end
 end

--- a/db/migrate/20200204100524_change_column_to_review_requests.rb
+++ b/db/migrate/20200204100524_change_column_to_review_requests.rb
@@ -1,0 +1,8 @@
+class ChangeColumnToReviewRequests < ActiveRecord::Migration[6.0]
+  def change
+    change_column :review_requests, :user_id, :integer
+    add_column :review_requests, :request_status, :string
+    add_column :review_requests, :postscript, :string
+    add_column :review_requests, :is_frozen, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_04_094051) do
+ActiveRecord::Schema.define(version: 2020_02_04_100524) do
 
   create_table "review_requests", force: :cascade do |t|
-    t.string "user_id", default: "guest"
+    t.integer "user_id"
     t.string "title", null: false
     t.string "text", null: false
     t.boolean "is_open", default: true
     t.integer "review_count", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "request_status"
+    t.string "postscript"
+    t.boolean "is_frozen", default: false
     t.index ["text"], name: "index_review_requests_on_text", unique: true
     t.index ["title"], name: "index_review_requests_on_title", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2020_02_04_100524) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "request_status"
-    t.string "postscript"
+    t.string "additional_remark"
     t.boolean "is_frozen", default: false
     t.index ["text"], name: "index_review_requests_on_text", unique: true
     t.index ["title"], name: "index_review_requests_on_title", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2020_02_04_100524) do
   create_table "tags", force: :cascade do |t|
     t.string "tag_name"
     t.integer "request_id"
-    t.boolean "is_frozen", default: false
+    t.boolean "is_pinned", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_28_065144) do
+ActiveRecord::Schema.define(version: 2020_02_04_094051) do
 
   create_table "review_requests", force: :cascade do |t|
     t.string "user_id", default: "guest"
@@ -22,6 +22,14 @@ ActiveRecord::Schema.define(version: 2020_01_28_065144) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["text"], name: "index_review_requests_on_text", unique: true
     t.index ["title"], name: "index_review_requests_on_title", unique: true
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "tag_name"
+    t.integer "request_id"
+    t.boolean "is_frozen", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
 end

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要  
* レビューリクエストにカラムを追加しました。
* タグテーブルを追加しました。  
* レビューに付与するユーザーIDを、change_columnメソッドでstringではなく数字に変更できることの確認と変更をしました。また、defaultのゲストを外しました。ユーザーテーブルの実際の実装次第だとは思いますが、IDは連番の数字の可能性が高そうなので先に変更しておきました。いつでもchange_columnメソッドで変更できます。  


## 追加したカラム  
### tags
* tag_name（タグ自体の名前）
* request_id （紐づけするレビューリクエストのID）
* is_pinned（オーナーからのピン止め状態・外したくないタグにオーナーが付ける）
### review_requests
* request_status（リクエストの状態:freeze, :free, :limitedの保持）
* postscript（そのままP.Sの意味です）
* is_frozen（管理者が強制的に閉じるときのためのカラム、将来的に必要かと思って）

# レビューしてほしいポイント
他に必要そうなカラムがないか、また、カラム名のわかりやすさなど 

# 許してほしいこと
 概要の3つ目に関して、コミットを分けるべきでした。
そもそもPRの名前がAdd tags tableなのにreview_requestsに関する変更が含まれていたり、なんか気持ち悪いのでPR分けるべきでした。