### PR TITLE
Change wiki url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@
 /yarn-error.log
 
 .byebug_history
-wiki

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 /yarn-error.log
 
 .byebug_history
+wiki

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "wiki"]
 	path = wiki
 	url = git@github.com:kotarou1192/Co-review.wiki.git
-	ignore = dirty
+	ignore = all

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "wiki"]
 	path = wiki
 	url = git@github.com:kotarou1192/Co-review.wiki.git
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wiki"]
 	path = wiki
-	url = https://github.com/kotarou1192/Co-review.wiki.git
+	url = git@github.com:kotarou1192/Co-review.wiki.git


### PR DESCRIPTION
# 概要

WikiのURLをhttps://github/ で登録していたがsshの公開鍵認証に変更

## やったこと

- sshの公開鍵認証で使用している人が多いはずなので、sshのURLに変更
- wikiでの変更を親リポジトリに対して修正とならないようにignore=allを追加

## 懸念点

特にないです！