### PR TITLE
update review requests and tags

### DIFF
--- a/app/controllers/review_requests_controller.rb
+++ b/app/controllers/review_requests_controller.rb
@@ -64,7 +64,7 @@ class ReviewRequestsController < ApplicationController
     all_tag_names.map do |tag_name|
       raise ArgumentError, "タグ名が長すぎます。#{MAX_TAG_CHARS_COUNT}文字までにして下さい。" if tag_name.size > MAX_TAG_CHARS_COUNT
 
-      Tag.new(tag_name: tag_name, request_id: id, pinned: true)
+      Tag.new(name: tag_name, review_request_id: id, pinned: true)
     end
   end
 

--- a/app/controllers/review_requests_controller.rb
+++ b/app/controllers/review_requests_controller.rb
@@ -1,6 +1,7 @@
 class ReviewRequestsController < ApplicationController
   def show
     @review_request = ReviewRequest.find(params[:id])
+    @tags = Tag.where(review_request_id: @review_request.id)
   end
 
   def index
@@ -8,11 +9,16 @@ class ReviewRequestsController < ApplicationController
   end
 
   def new
+    @tag_name_error_messages ||= []
     @review_request = ReviewRequest.new
+    @tags = Tag::MAX_TAGS_COUNT.times.map { Tag.new }
   end
 
   def create
     @review_request = ReviewRequest.new(review_request_params)
+    @tags = Tag::MAX_TAGS_COUNT.times.map do |num|
+      Tag.new(tag_params[num.to_s])
+    end
     # p '------'
     # p params
     # p '------'
@@ -25,18 +31,35 @@ class ReviewRequestsController < ApplicationController
     # permitted: false>
     # "------"
 
-    return render action: :new unless @review_request.valid?
+    @tag_name_error_messages = Tag.create_tag_error_messages(@tags)
+
+    return render action: :new unless @review_request.valid? && Tag.any_tag_name_length_too_long?(@tags) && Tag.all_tag_names_unique?(@tags)
 
     ActiveRecord::Base.transaction do
       @review_request.save!
+      save_tags(@review_request.id)
     end
     redirect_to @review_request
   end
 
   private
 
+  def save_tags(review_request_id)
+    @tags.each do |tag|
+      next if tag.name.empty?
+
+      tag.review_request_id = review_request_id
+      tag.pinned = true
+      tag.save!
+    end
+  end
+
   def review_request_params
     # for safety, choose only required parameters
     params.require(:review_request).permit(:title, :text)
+  end
+
+  def tag_params
+    params[:tag].permit!.to_h
   end
 end

--- a/app/controllers/review_requests_controller.rb
+++ b/app/controllers/review_requests_controller.rb
@@ -17,7 +17,7 @@ class ReviewRequestsController < ApplicationController
   def create
     @review_request = ReviewRequest.new(review_request_params)
     @tags = Tag::MAX_TAGS_COUNT.times.map do |num|
-      Tag.new(tag_params[num.to_s])
+      Tag.new(tag_params(num))
     end
     # p '------'
     # p params
@@ -59,7 +59,7 @@ class ReviewRequestsController < ApplicationController
     params.require(:review_request).permit(:title, :text)
   end
 
-  def tag_params
-    params[:tag].permit!.to_h
+  def tag_params(num)
+    params.require(:tag).require(num.to_s).permit(:name)
   end
 end

--- a/app/models/review_request.rb
+++ b/app/models/review_request.rb
@@ -1,4 +1,5 @@
 class ReviewRequest < ApplicationRecord
+  has_many :tag, dependent: :destroy
   validates :title, presence: true, length: { maximum: 120 }, uniqueness: true
   validates :text, presence: true, length: { maximum: 2000 }, uniqueness: true
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,38 @@
 class Tag < ApplicationRecord
   belongs_to :review_request
-  validates :name, presence: true, length: { maximum: 16 }
+  validates :name, length: { maximum: 16 }
+
+  MAX_TAGS_COUNT = 10
+  MAX_TAG_CHARS_COUNT = 16
+
+  def self.all_tag_names_unique?(tags)
+    all_tag_names = tags.map(&:name).reject(&:blank?)
+    (all_tag_names.size - all_tag_names.uniq.size).zero?
+  end
+
+  def self.any_tag_name_length_too_long?(tags)
+    tags.all? do |tag|
+      tag.name.size <= MAX_TAG_CHARS_COUNT
+    end
+  end
+
+  def self.create_tag_error_messages(tags)
+    error_messages = []
+
+    tags.each_with_index do |tag, index|
+      next if tag.name.empty?
+
+      if tag.name.size > MAX_TAG_CHARS_COUNT
+        error_messages.push "#{tag.name} is too long. max size is #{MAX_TAG_CHARS_COUNT}"
+      end
+      next if all_tag_names_unique?(tags)
+
+      tags.each_with_index do |t, i|
+        next if i == index
+
+        error_messages.push "#{tag.name} is duplicated" if tag.name == t.name
+      end
+    end
+    error_messages.uniq
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,3 @@
 class Tag < ApplicationRecord
+  belongs_to :review_request
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,4 @@
 class Tag < ApplicationRecord
   belongs_to :review_request
+  validates :name, presence: true, length: { maximum: 16 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,4 @@
+class User < ApplicationRecord
+  has_many :review_requests, :likes, :bookmarks, :response_reviews
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/views/review_requests/new.html.erb
+++ b/app/views/review_requests/new.html.erb
@@ -20,6 +20,16 @@
           <% end %>
         </div>
       <% end %>
+      <% unless @tag_name_error_messages.empty? %>
+        <div class="error-list">
+          <p class="error-list__head">TagError</p>
+          <% @tag_name_error_messages.each do |message| %>
+            <li class="error-list__message">
+              <%= message %>
+            </li>
+          <% end %>
+        </div>
+      <% end %>
 
       <%= f.text_field :title,
         class: "post-request__interface post-request__interface_input-title" %>
@@ -28,8 +38,12 @@
         class: "post-request__interface post-request__interface_submit" %>
 
       
-      <p class="post-request__text">タグを半角スペース区切りで入力</p>
-      <input id="tags" name="tags" value="<%= @tag_names_text %>" type="text" class="post-request__interface post-request__interface_input-tags">
+      <p class="post-request__text">タグを10個まで入力出来ます</p>
+        <% @tags.each_with_index do |tag, index| %>
+          <%= fields_for tag do |f| %>
+            <%= f.text_field :name, index: index %>
+          <% end %>
+        <% end %>
       
       <p class="post-request__text">本文を入力</p>
 

--- a/app/views/review_requests/new.html.erb
+++ b/app/views/review_requests/new.html.erb
@@ -12,7 +12,7 @@
     <%= form_for(@review_request, html: {class: "post-request"}) do |f| %>
       <% if @review_request.errors.any? %>
         <div class="error-list">
-          <p class="error-list__head">Error</p>
+          <p class="error-list__head">ReviewRequestError</p>
           <% @review_request.errors.full_messages.each do |message| %>
           <li class="error-list__message">
             <%= message %>

--- a/app/views/review_requests/show.html.erb
+++ b/app/views/review_requests/show.html.erb
@@ -22,6 +22,17 @@
 
     <div class="content">
 
+      <div>
+        <% if @tags.any? %>
+          <ul style="list-style: none;">
+            <li style="float: left;">タグ:</li>
+            <% @tags.each do |tag| %>
+              <li style="float: left; margin-left: 10px;"><%= tag.name %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+
       <div class="review-request">
         <p>
           <%= render partial: 'layouts/review_request_card',


### PR DESCRIPTION
## タグの実装を大幅に変更しました。
タグの再実装を行いました。
タグの実装は以前よりも妥当になったでしょうか？
それと、どのタグがエラーを起こしているかを表示するようにしました。

### 何をしたか
```ruby
  def new
    @tag_name_error_messages ||= []
    @review_request = ReviewRequest.new
    @tags = Tag::MAX_TAGS_COUNT.times.map { Tag.new }
  end
```
ここの`@tags = Tag::MAX_TAGS_COUNT.times.map { Tag.new }`でタグをN個作ってビューに渡したあと

`"tag"=>{"0"=>{"name"=>"これ"}, "1"=>{"name"=>"が"}, "2"=>{"name"=>"タグです"}, "3"=>{"name"=>""}, "4"=>{"name"=>""}, "5"=>{"name"=>""}, "6"=>{"name"=>""}, "7"=>{"name"=>""}, "8"=>{"name"=>""}, "9"=>{"name"=>""}}`

という形で入力されたタグを受け取り

```ruby
    @tags = Tag::MAX_TAGS_COUNT.times.map do |num|
      Tag.new(tag_params(num))
    end
```

ここでその値を受け取ってTagをN個Newしています。
その後それをバリデーションにかけてOKだったらレビューリクエストとの関連付けを行いsave_tags関数で保存しています。

### 不安なところ、失敗したなと思ったところ
- `belongs_to :review_request`を付与したため、review_request_idのカラムが空の状態だと`valid?`メソッドが働かず、やむなく`any_tag_name_length_too_long?`関数（どれかのタグ名が長さオーバーしてないか確認する関数）を追加することになってしまいました。
- 関数の命名が適切かどうかはいつも不安です(最近、１関数に１機能を意識すれば自明な命名になりやすいというのに気づき始めました)。
- create_tag_error_messages関数が少し複雑すぎるかなと思いました。


### 変更後のタグ入力画面
![スクリーンショット 2020-06-17 21 22 31](https://user-images.githubusercontent.com/51397938/84979160-b388f080-b169-11ea-83f5-b9a4f7118a9a.png)

### タグの重複エラーと長さ超過エラー
![2020-06-17_4 40 45](https://user-images.githubusercontent.com/51397938/84979184-c8658400-b169-11ea-969c-8b6de4544fbd.png)

### 投稿成功後、タグが表示されている様子
![スクリーンショット 2020-06-18 13 46 01](https://user-images.githubusercontent.com/51397938/84979298-1084a680-b16a-11ea-8551-42656cf9e065.png)
